### PR TITLE
Changed example to use non-HTTPS site to avoid 301 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ transaction over a TCPSocket.
 To use the example with a different interface, you will need to modify main.cpp and
 replace the EthernetInterface class with the appropriate interface.
 
+### Expected output ###
+
+```
+IP address: 10.118.14.45
+Netmask: 255.255.252.0
+Gateway: 10.118.12.1
+sent 39 [GET / HTTP/1.1]
+recv 173 [HTTP/1.1 200 OK]
+External IP address: 217.140.111.135
+Done
+```
+
 ### Documentation ###
 
 More information on the network-socket API can be found in the [mbed handbook](https://docs.mbed.com/docs/mbed-os-api-reference/en/latest/APIs/communication/network_sockets/).

--- a/main.cpp
+++ b/main.cpp
@@ -12,25 +12,34 @@ int main() {
 
     // Show the network address
     const char *ip = net.get_ip_address();
-    printf("IP address is: %s\n", ip ? ip : "No IP");
+    const char *netmask = net.get_netmask();
+    const char *gateway = net.get_gateway();
+    printf("IP address: %s\n", ip ? ip : "None");
+    printf("Netmask: %s\n", netmask ? netmask : "None");
+    printf("Gateway: %s\n", gateway ? gateway : "None");
 
     // Open a socket on the network interface, and create a TCP connection to mbed.org
     TCPSocket socket;
     socket.open(&net);
-    socket.connect("developer.mbed.org", 80);
+    socket.connect("api.ipify.org", 80);
+    char *buffer = new char[256];
 
     // Send an HTTP request
-    char sbuffer[] = "GET / HTTP/1.1\r\nHost: developer.mbed.org\r\n\r\n";
-    int scount = socket.send(sbuffer, sizeof sbuffer);
-    printf("sent %d [%.*s]\n", scount, strstr(sbuffer, "\r\n")-sbuffer, sbuffer);
+    strcpy(buffer, "GET / HTTP/1.1\r\nHost: api.ipify.org\r\n\r\n");
+    int scount = socket.send(buffer, strlen(buffer));
+    printf("sent %d [%.*s]\n", scount, strstr(buffer, "\r\n")-buffer, buffer);
 
-    // Receive an http response and print out the response line
-    char rbuffer[64];
-    int rcount = socket.recv(rbuffer, sizeof rbuffer);
-    printf("recv %d [%.*s]\n", rcount, strstr(rbuffer, "\r\n")-rbuffer, rbuffer);
+    // Recieve an HTTP response and print out the response line
+    int rcount = socket.recv(buffer, 256);
+    printf("recv %d [%.*s]\n", rcount, strstr(buffer, "\r\n")-buffer, buffer);
+
+    // The api.ipify.org service also gives us the device's external IP address
+    const char *payload = strstr(buffer, "\r\n\r\n")+4;
+    printf("External IP address: %.*s\n", rcount-(payload-buffer), payload);
 
     // Close the socket to return its memory and bring down the network interface
     socket.close();
+    delete[] buffer;
 
     // Bring down the ethernet interface
     net.disconnect();


### PR DESCRIPTION
Adopted ipify.org (thanks @bridadan). This avoids the redirect for HTTPS.

```
IP address: 10.118.14.45
Netmask: 255.255.252.0
Gateway: 10.118.12.1
sent 39 [GET / HTTP/1.1]
recv 173 [HTTP/1.1 200 OK]
External IP address: 217.140.111.135
Done
```

Should take care of https://github.com/ARMmbed/mbed-os-example-sockets/issues/21
cc @maclobdell, @bridadan 