### PR TITLE
Update the network socket API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Done
 
 ### Documentation ###
 
-More information on the network-socket API can be found in the [mbed handbook](https://docs.mbed.com/docs/mbed-os-api-reference/en/latest/APIs/communication/network_sockets/).
+More information on the network-socket API can be found in the [API documentation](https://os.mbed.com/docs/latest/reference/network-socket.html).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Change the NSAPI doc link from the old https://docs.mbed.com/docs/mbed-os-api-reference/en/latest/APIs/communication/network_sockets/ to the newer link (https://os.mbed.com/docs/latest/reference/network-socket.html) that is used above in this readme.
FYI @AnotherButler @MarceloSalazar 