### PR TITLE
Support for easy-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This is a quick example of a simple HTTP client program using the
 The program brings up an underlying network interface, and uses it to perform an HTTP
 transaction over a TCPSocket.
 
-**Note:** The current example is limited to the ethernet interface on supported devices.
-To use the example with a different interface, you will need to modify main.cpp and
-replace the EthernetInterface class with the appropriate interface.
+This example uses [easy-connect](https://github.com/ARMmbed/easy-connect/) as the network bearer abstraction model. Please configure the `mbed_app.json` accordingly to use the network stack you want to use.
 
 ### Building
 
@@ -23,12 +21,17 @@ For example, building for K64F using GCC: `mbed compile -t GCC_ARM -m K64F`
 **Note:** The default serial port baud rate is 9600 bit/s.
 
 ```
-IP address: 10.118.14.45
-Netmask: 255.255.252.0
-Gateway: 10.118.12.1
-sent 39 [GET / HTTP/1.1]
-recv 173 [HTTP/1.1 200 OK]
-External IP address: 217.140.111.135
+[EasyConnect] IPv4 mode
+[EasyConnect] Using Ethernet
+[EasyConnect] Connected to Network successfully
+[EasyConnect] MAC address 02:46:38:b7:e9:a8
+[EasyConnect] IP address 10.45.0.44
+IP address: 10.45.0.44
+Netmask: 255.255.254.0
+Gateway: 10.45.0.1
+sent 58 [GET / HTTP/1.1]https://github.com/ARMmbed/easy-connect/
+recv 181 [HTTP/1.1 200 OK]
+External IP address: 217.140.96.140
 Done
 ```
 

--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/easy-connect/#21a78a40e94ba9298e05ce54738c6b42657ae010

--- a/main.cpp
+++ b/main.cpp
@@ -1,26 +1,27 @@
 #include "mbed.h"
-#include "EthernetInterface.h"
-
-// Network interface
-EthernetInterface net;
+#include "easy-connect.h"
 
 // Socket demo
 int main() {
-    // Bring up the ethernet interface
-    printf("Ethernet socket example\n");
-    net.connect();
+
+    // Use easy-connect for abstract network handling.
+    NetworkInterface* net = easy_connect(true);
+    if (!net) {
+        printf("ERROR - connecting to the network failed... See serial output.\r\n");
+        return 1;
+    }
 
     // Show the network address
-    const char *ip = net.get_ip_address();
-    const char *netmask = net.get_netmask();
-    const char *gateway = net.get_gateway();
+    const char *ip = net->get_ip_address();
+    const char *netmask = net->get_netmask();
+    const char *gateway = net->get_gateway();
     printf("IP address: %s\n", ip ? ip : "None");
     printf("Netmask: %s\n", netmask ? netmask : "None");
     printf("Gateway: %s\n", gateway ? gateway : "None");
 
     // Open a socket on the network interface, and create a TCP connection to mbed.org
     TCPSocket socket;
-    socket.open(&net);
+    socket.open(net);
     socket.connect("api.ipify.org", 80);
     char *buffer = new char[256];
 
@@ -50,6 +51,6 @@ int main() {
     delete[] buffer;
 
     // Bring down the ethernet interface
-    net.disconnect();
+    net->disconnect();
     printf("Done\n");
 }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,4 +1,27 @@
 {
+    "config": {
+        "network-interface":{
+            "help": "options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_IDW0XX1, WIFI_RTW, MESH_LOWPAN_ND, MESH_THREAD",
+            "value": "ETHERNET"
+        },
+        "esp8266-tx": {
+            "help": "Pin used as TX (connects to ESP8266 RX)",
+            "value": "PTD3"
+        },
+        "esp8266-rx": {
+            "help": "Pin used as RX (connects to ESP8266 TX)",
+            "value": "PTD2"
+        },
+        "esp8266-debug": {
+            "value": false
+        },
+        "wifi-ssid": {
+            "value": "\"SSID\""
+        },
+        "wifi-password": {
+            "value": "\"password\""
+        }
+    },
     "target_overrides": {
         "*": {
             "platform.stdio-convert-newlines": true


### PR DESCRIPTION
The helper library easy-connect offers a way to more abstractly
define the networks being used.