### PR TITLE
Updating mbed-os to mbed-os-5.10.2

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c53d51fe9220728bf8ed27afe7afc1ecc3f6f5d7
+https://github.com/ARMmbed/mbed-os/#e1bea44212b8275f7d8ce7253e758c2e25c57482


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.10.2 . 