### PR TITLE
README.md: remove the External address line form sample output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Netmask: 255.255.252.0
 Gateway: 10.118.12.1
 sent 39 [GET / HTTP/1.1]
 recv 173 [HTTP/1.1 200 OK]
-External IP address: 217.140.111.135
 Done
 ```
 


### PR DESCRIPTION
Fixes https://github.com/ARMmbed/mbed-os-example-sockets/issues/132

We had to switch from ipify.org to ifconfig.io, in order to handle IPV6 addresses correctly. ifconfig.io does not return the external IP address line, os that line should be removed from the sample output in README.md file.