### PR TITLE
Remove usage of deprecated string-based API

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -32,12 +32,13 @@ int main() {
     }
 
     // Show the network address
-    const char *ip = net->get_ip_address();
-    const char *netmask = net->get_netmask();
-    const char *gateway = net->get_gateway();
-    printf("IP address: %s\n", ip ? ip : "None");
-    printf("Netmask: %s\n", netmask ? netmask : "None");
-    printf("Gateway: %s\n", gateway ? gateway : "None");
+    SocketAddress a;
+    net->get_ip_address(&a);
+    printf("IP address: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
+    net->get_netmask(&a);
+    printf("Netmask: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
+    net->get_gateway(&a);
+    printf("Gateway: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
 
     // Open a socket on the network interface, and create a TCP connection to ifconfig.io
     TCPSocket socket;

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#51d55508e8400b60af467005646c4e2164738d48
+https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7


### PR DESCRIPTION
String-based APIs were marked deprecated and replaced by `SocketAddress`-based APIs in https://github.com/ARMmbed/mbed-os/pull/11914.
This PR switches the example to the new API and removes the deprecated one.
To get this compile I updated `mbed-os.lib` version to 5.15.
This blocks https://github.com/ARMmbed/mbed-os/pull/11942