### PR TITLE
Unify example and add wifi functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.DS_Store
+
+# clion
+.idea/
+cmake-build-*/
+
+# exporters
+GettingStarted.html
+eclipse-extras/
+
+# mbed build system
+mbed-os/
+mbed_settings.py
+mbed_config.h
+*.pyc
+BUILD/
+cmake-build-debug/

--- a/COMPONENT_ism43362.lib
+++ b/COMPONENT_ism43362.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/wifi-ism43362/#9e1851a7fe5e2ffb07533aacc7114df2e73f7784

--- a/COMPONENT_ism43362.lib
+++ b/COMPONENT_ism43362.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/wifi-ism43362/#9e1851a7fe5e2ffb07533aacc7114df2e73f7784
+https://github.com/ARMmbed/wifi-ism43362/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](./resources/official_armmbed_example_badge.png)
 # Socket Example
 
-This example shows usage of [network-socket API](https://os.mbed.com/docs/latest/reference/network-socket.html).
+This example shows usage of [network-socket API](https://os.mbed.com/docs/mbed-os/latest/apis/network-socket.html).
 
 The program brings up an underlying network interface and if it's Wifi also scans for access points.
 It creates a TCPSocket and performs an HTTP transaction targeting the website in the `mbed_app.json` config.
@@ -12,9 +12,13 @@ please see [the documentation](https://os.mbed.com/docs/mbed-os/latest/apis/sock
 ## Selecting the network interface
 
 This application is able to use any network interface it finds.
-Please see the Mbed OS documentation for [selecting the default network interface](https://os.mbed.com/docs/v5.10/apis/network-interfaces.html).
 
-For example, building on Ethernet enabled boards, you do not need any further configuration.
+The interface selections is done through weak functions that are overridden by your selected target or any additional
+component that provides a network interface.
+
+If more than one interface is provided the target configuration `target.network-default-interface-type`
+selects the type provided as the default one. This is usually the Ethernet so building on Ethernet enabled boards,
+you do not need any further configuration.
 
 ### WiFi
 
@@ -32,32 +36,34 @@ If your board doesn't provide WiFi as the default interface because it has multi
 }
 ```
 
-For more information about Wi-Fi APIs, please visit the [Mbed OS Wi-Fi](https://os.mbed.com/docs/latest/reference/wi-fi.html) documentation.
+For more information about Wi-Fi APIs, please visit the [Mbed OS Wi-Fi](https://os.mbed.com/docs/mbed-os/latest/apis/wi-fi.html) documentation.
 
 ### Supported WiFi hardware
 
-* All Mbed OS boards with build-in Wi-Fi module:
+* All Mbed OS boards with build-in Wi-Fi module such as:
     * [ST DISCO IOT board](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/) with integrated [ISM43362 WiFi Inventek module](https://github.com/ARMmbed/wifi-ism43362).
     * [ST DISCO_F413ZH board](https://os.mbed.com/platforms/ST-Discovery-F413H/) with integrated [ISM43362 WiFi Inventek module](https://github.com/ARMmbed/wifi-ism43362).
-* Boards with external WiFi shields.
-    * [NUCLEO-F429ZI](https://os.mbed.com/platforms/ST-Nucleo-F429ZI/) with ESP8266-01 module using pins D1 and D0.
+* Boards with external WiFi shields such as:
+    * [NUCLEO-F429ZI](https://os.mbed.com/platforms/ST-Nucleo-F429ZI/) with ESP8266-01
 
 ## Building and flashing the example
 
 ### To build the example
 
-Clone the repository containing the collection of examples:
+Clone the repository containing example:
 
 ```
 git clone https://github.com/ARMmbed/mbed-os-example-sockets.git
-cd mbed-os-example-sockets
 ```
 
 **Tip:** If you don't have git installed, you can [download a zip file](https://github.com/ARMmbed/mbed-os-example-sockets/archive/master.zip) of the repository.
 
 Update the source tree:
 
-```mbed deploy```
+```
+cd mbed-os-example-sockets
+mbed deploy
+```
 
 Run the build:
 
@@ -69,6 +75,9 @@ Connect your mbed board to your computer over USB. It appears as removable stora
 
 When you run the `mbed compile` command above, mbed cli creates a .bin or a .hex file (depending on your target) in
 ```BUILD/<target-name>/<toolchain>``` under the example's directory. Drag and drop the file to the removable storage.
+
+Alternatively you may launch compilation with `-f` flag to have mbed tools attempt to flash your board.
+The tools will flash the binary to all targets that match the board specified by '-m' parameter. 
 
 ## Running the example
 

--- a/README.md
+++ b/README.md
@@ -1,76 +1,122 @@
 ![](./resources/official_armmbed_example_badge.png)
-## Getting started with the network-socket API
+# Socket Example
 
-(Note: To see this example in a rendered form you can import into the Arm Mbed Online Compiler, please see [the documentation](https://os.mbed.com/docs/mbed-os/latest/apis/socket.html#socket-example).)
+This example shows usage of [network-socket API](https://os.mbed.com/docs/latest/reference/network-socket.html).
 
-This is a quick example of a simple HTTP client program using the
-[network-socket API](https://os.mbed.com/docs/latest/reference/network-socket.html) that [Mbed OS](https://github.com/ARMmbed/mbed-os) provides.
+The program brings up an underlying network interface and if it's Wifi also scans for access points.
+It creates a TCPSocket and performs an HTTP transaction targeting the website in the `mbed_app.json` config.
 
-The program brings up an underlying network interface, and uses it to perform an HTTP
-transaction over a TCPSocket.
+(Note: To see this example in a rendered form you can import into the Arm Mbed Online Compiler,
+please see [the documentation](https://os.mbed.com/docs/mbed-os/latest/apis/socket.html#socket-example).)
 
-### Selecting the network interface
+## Selecting the network interface
 
-This application is able to use any network inteface it finds. Please see the Mbed OS documentationg for [selecting the default network interface](https://os.mbed.com/docs/v5.10/apis/network-interfaces.html).
+This application is able to use any network interface it finds.
+Please see the Mbed OS documentation for [selecting the default network interface](https://os.mbed.com/docs/v5.10/apis/network-interfaces.html).
 
-For example, building on Ethernet enabled boards, you do not do any configuration.
+For example, building on Ethernet enabled boards, you do not need any further configuration.
 
-Building for WiFi boards, you need to provide SSID, password and security settings in `mbed_app.json` as instructed in the documentation. For example, like this:
+### WiFi
+
+If you want to use WiFi you need to provide SSID, password and security settings in `mbed_app.json`.
+
+If your board doesn't provide WiFi as the default interface because it has multiple interfaces you need to specify that you want WiFi in `mbed_app.json`.
 
 ```
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true,
             "target.network-default-interface-type": "WIFI",
-            "nsapi.default-wifi-security": "WPA_WPA2",
-            "nsapi.default-wifi-ssid": "\"ssid\"",
-            "nsapi.default-wifi-password": "\"password\""
         }
     }
 }
 ```
 
-Building for boards that have more that one network interface, you might need to override `target.network-default-interface-type` variable.
+For more information about Wi-Fi APIs, please visit the [Mbed OS Wi-Fi](https://os.mbed.com/docs/latest/reference/wi-fi.html) documentation.
 
-### Building
+### Supported WiFi hardware
+
+* All Mbed OS boards with build-in Wi-Fi module:
+    * [ST DISCO IOT board](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/) with integrated [ISM43362 WiFi Inventek module](https://github.com/ARMmbed/wifi-ism43362).
+    * [ST DISCO_F413ZH board](https://os.mbed.com/platforms/ST-Discovery-F413H/) with integrated [ISM43362 WiFi Inventek module](https://github.com/ARMmbed/wifi-ism43362).
+* Boards with external WiFi shields.
+    * [NUCLEO-F429ZI](https://os.mbed.com/platforms/ST-Nucleo-F429ZI/) with ESP8266-01 module using pins D1 and D0.
+
+## Building and flashing the example
+
+### To build the example
+
+Clone the repository containing the collection of examples:
 
 ```
-mbed compile -t <toolchain> -m <target>
+git clone https://github.com/ARMmbed/mbed-os-example-sockets.git
+cd mbed-os-example-sockets
 ```
 
-For example, building for K64F using GCC: `mbed compile -t GCC_ARM -m K64F`
+**Tip:** If you don't have git installed, you can [download a zip file](https://github.com/ARMmbed/mbed-os-example-sockets/archive/master.zip) of the repository.
 
-### Expected output ###
+Update the source tree:
 
-**Note:** The default serial port baud rate is 9600 bit/s.
+```mbed deploy```
+
+Run the build:
+
+```mbed compile -t <ARM | GCC_ARM> -m <YOUR_TARGET>```
+
+### To flash the example onto your board
+
+Connect your mbed board to your computer over USB. It appears as removable storage.
+
+When you run the `mbed compile` command above, mbed cli creates a .bin or a .hex file (depending on your target) in
+```BUILD/<target-name>/<toolchain>``` under the example's directory. Drag and drop the file to the removable storage.
+
+## Running the example
+
+
+When example application is running information about activity is printed over the serial connection.
+
+**Note:** The default serial baudrate has been set to 115200.
+
+Please have a client open and connected to the board. You may use:
+
+- [Tera Term](https://ttssh2.osdn.jp/index.html.en) for windows
+
+- screen or minicom for Linux (example usage: `screen /dev/serial/<your board> 115200`)
+
+### Expected output
+
+(Assuming you are using a wifi interface, otherwise the scanning will be skipped)
 
 ```
-Mbed OS Socket example
-Mbed OS version: 5.15.0
+Starting socket demo
 
-IP address: 10.45.3.17
+2 networks available:
+Network: Virgin Media secured: Unknown BSSID: 2A:35:D1:ba:c7:41 RSSI: -79 Ch: 6
+Network: VM4392164 secured: WPA2 BSSID: 18:35:D1:ba:c7:41 RSSI: -79 Ch: 6
+
+Connecting to the network...
+IP address: 192.168.0.27
 Netmask: 255.255.255.0
-Gateway: 10.45.3.1
+Gateway: 192.168.0.1
 
 Resolve hostname ifconfig.io
 ifconfig.io address is 104.24.122.146
-sent 56 [GET / HTTP/1.1]
-recv 256 [HTTP/1.1 200 OK]
-Done
+
+sent 52 bytes: 
+GET / HTTP/1.1
+Host: ifconfig.io
+Connection: close
+
+received 256 bytes:
+HTTP/1.1 200 OK
+
+Demo concluded successfully 
 ```
-
-### Documentation ###
-
-More information on the network-socket API can be found in the [mbed handbook](https://docs.mbed.com/docs/mbed-os-api-reference/en/latest/APIs/communication/network_sockets/).
-
-## Troubleshooting
-
-If you have problems, you can review the [documentation](https://os.mbed.com/docs/latest/tutorials/debugging.html) for suggestions on what could be wrong and how to fix it.
 
 ## License and contributions
 
-The software is provided under Apache-2.0 license. Contributions to this project are accepted under the same license. Please see [contributing.md](CONTRIBUTING.md) for more info.
+The software is provided under Apache-2.0 license. Contributions to this project are accepted under the same license.
+Please see [contributing.md](CONTRIBUTING.md) for more info.
 
-This project contains code from other projects. The original license text is included in those source files. They must comply with our license guide.
-
+This project contains code from other projects. The original license text is included in those source files.
+They must comply with our license guide

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Please have a client open and connected to the board. You may use:
 
 - screen or minicom for Linux (example usage: `screen /dev/serial/<your board> 115200`)
 
+- mbed tools have terminal command `mbed term -b 115200`
+
 ### Expected output
 
 (Assuming you are using a wifi interface, otherwise the scanning will be skipped)

--- a/main.cpp
+++ b/main.cpp
@@ -1,109 +1,228 @@
+/* Sockets Example
+ * Copyright (c) 2016-2020 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 
-// Network interface
-NetworkInterface *net;
+class SocketDemo {
+    static const size_t MAX_NUMBER_OF_ACCESS_POINTS = 10;
+    static const size_t MAX_MESSAGE_RECEIVED_LENGTH = 100;
 
-// Socket demo
-int main() {
-    int remaining;
-    int rcount;
-    char *p;
-    char buffer[256];
-    nsapi_size_or_error_t result;
-
-    // Bring up the ethernet interface
-    printf("Mbed OS Socket example\n");
-
-#ifdef MBED_MAJOR_VERSION
-    printf("Mbed OS version: %d.%d.%d\n\n", MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION);
-#endif
-
-    net = NetworkInterface::get_default_instance();
-
-    if (!net) {
-        printf("Error! No network inteface found.\n");
-        return 0;
+public:
+    SocketDemo()
+    {
+        _net = NetworkInterface::get_default_instance();
     }
 
-    result = net->connect();
-    if (result != 0) {
-        printf("Error! net->connect() returned: %d\n", result);
-        return result;
+    ~SocketDemo()
+    {
+        _net->disconnect();
     }
 
-    // Show the network address
-    SocketAddress a;
-    net->get_ip_address(&a);
-    printf("IP address: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
-    net->get_netmask(&a);
-    printf("Netmask: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
-    net->get_gateway(&a);
-    printf("Gateway: %s\n", a.get_ip_address() ? a.get_ip_address() : "None");
-
-    // Open a socket on the network interface, and create a TCP connection to ifconfig.io
-    TCPSocket socket;
-    // Send a simple http request
-    char hostname[] = "ifconfig.io";
-    char sbuffer[] = "GET / HTTP/1.1\r\nHost: ifconfig.io\r\nConnection: close\r\n\r\n";
-    nsapi_size_t size = strlen(sbuffer);
-
-    result = socket.open(net);
-    if (result != 0) {
-        printf("Error! socket.open() returned: %d\n", result);
-        goto DISCONNECT;
-    }
-
-    // Get the host address
-    printf("\nResolve hostname %s\n", hostname);
-    result = net->gethostbyname(hostname, &a);
-    if (result != 0) {
-        printf("Error! gethostbyname(%s) returned: %d\n", hostname, result);
-        net->disconnect();
-        exit(-1);
-    }
-    printf("%s address is %s\n", hostname, (a.get_ip_address() ? a.get_ip_address() : "None") );
-
-    a.set_port(80);
-    result = socket.connect(a);
-    if (result != 0) {
-        printf("Error! socket.connect() returned: %d\n", result);
-        net->disconnect();
-        exit(-2);
-    }
-
-    // Loop until whole request sent
-    while (size) {
-        result = socket.send(sbuffer+result, size);
-        if (result < 0) {
-            printf("Error! socket.send() returned: %d\n", result);
-            goto DISCONNECT;
+    void run()
+    {
+        if (!_net) {
+            printf("Error! No network interface found.\r\n");
+            return;
         }
-        size -= result;
-        printf("sent %d [%.*s]\n", result, strstr(sbuffer, "\r\n")-sbuffer, sbuffer);
+
+        /* if we're using a wifi interface run a quick scan */
+        if (_net->wifiInterface()) {
+            wifi_scan();
+        }
+
+        /* connect will perform the action appropriate to the interface type to connect to the network */
+
+        printf("Connecting to the network...\r\n");
+
+        nsapi_size_or_error_t result = _net->connect();
+        if (result != 0) {
+            printf("Error! _net->connect() returned: %d\r\n", result);
+            return;
+        }
+
+        print_network_info();
+
+        /* opening the socket only allocates resources */
+        result = socket.open(_net);
+        if (result != 0) {
+            printf("Error! socket.open() returned: %d\r\n", result);
+            return;
+        }
+
+        /* now we have to find where to connect */
+        SocketAddress address;
+
+        if (!resolve_hostname(address)) {
+            return;
+        }
+
+        /* set standard HTTP port */
+        address.set_port(80);
+
+        /* finally connect */
+        result = socket.connect(address);
+        if (result != 0) {
+            printf("Error! socket.connect() returned: %d\r\n", result);
+            return;
+        }
+
+        /* exchange an HTTP request and response */
+
+        if (!send_http_request()) {
+            return;
+        }
+
+        if (!receive_http_response()) {
+            return;
+        }
+
+        printf("Demo concluded successfully \r\n");
     }
 
-    // Receieve an HTTP response and print out the response line
-    remaining = 256;
-    rcount = 0;
-    p = buffer;
-    while (remaining > 0 && 0 < (result = socket.recv(p, remaining))) {
-        p += result;
-        rcount += result;
-        remaining -= result;
+private:
+    bool resolve_hostname(SocketAddress &address)
+    {
+        const char hostname[] = MBED_CONF_APP_HOSTNAME;
+
+        /* get the host address */
+        printf("\nResolve hostname %s\r\n", hostname);
+        nsapi_size_or_error_t result = _net->gethostbyname(hostname, &address);
+        if (result != 0) {
+            printf("Error! gethostbyname(%s) returned: %d\r\n", hostname, result);
+            return false;
+        }
+
+        printf("%s address is %s\r\n", hostname, (address.get_ip_address() ? address.get_ip_address() : "None") );
+
+        return true;
     }
-    if (result < 0) {
-        printf("Error! socket.recv() returned: %d\n", result);
-        goto DISCONNECT;
+
+    bool send_http_request()
+    {
+        /* loop until whole request sent */
+        const char buffer[] = "GET / HTTP/1.1\nHost: ifconfig.io\nConnection: close\n\n";
+
+        nsapi_size_t bytes_to_send = strlen(buffer);
+
+        while (bytes_to_send) {
+            nsapi_size_or_error_t result = socket.send(buffer + result, bytes_to_send);
+            if (result < 0) {
+                printf("Error! socket.send() returned: %d\r\n", result);
+                return false;
+            }
+
+            bytes_to_send -= result;
+        }
+
+        printf("\r\nsent %d bytes: \r\n%s", strlen(buffer), buffer);
+
+        return true;
     }
-	// the HTTP response code
-    printf("recv %d [%.*s]\n", rcount, strstr(buffer, "\r\n")-buffer, buffer);
 
-DISCONNECT:
+    bool receive_http_response()
+    {
+        char buffer[MAX_MESSAGE_RECEIVED_LENGTH];
+        int remaining_bytes = MAX_MESSAGE_RECEIVED_LENGTH;
+        int received_bytes = 0;
 
-    // Close the socket to return its memory and bring down the network interface
-    socket.close();
+        /* loop until there is nothing received or we've ran out of buffer space */
+        while (remaining_bytes > 0) {
+            nsapi_size_or_error_t result = socket.recv(buffer + received_bytes, remaining_bytes);
+            if (result < 0) {
+                printf("Error! socket.recv() returned: %d\r\n", result);
+                return false;
+            }
 
-    // Bring down the ethernet interface
-    net->disconnect();
-    printf("Done\n");
+            received_bytes += result;
+            remaining_bytes -= result;
+        }
+
+        /* the message is likely larger but we only want the HTTP response code */
+
+        printf("received %d bytes:\r\n%.*s\r\n\r\n", received_bytes, strstr(buffer, "\n") - buffer, buffer);
+
+        return true;
+    }
+
+    void wifi_scan()
+    {
+        WiFiInterface *wifi = _net->wifiInterface();
+
+        WiFiAccessPoint ap[MAX_NUMBER_OF_ACCESS_POINTS];
+
+        /* scan call returns number of access points found */
+        int result = wifi->scan(ap, MAX_NUMBER_OF_ACCESS_POINTS);
+
+        if (result <= 0) {
+            printf("WiFiInterface::scan() failed with return value: %d\r\n", result);
+            return;
+        }
+
+        printf("%d networks available:\r\n", result);
+
+        for (int i = 0; i < result; i++) {
+            printf("Network: %s secured: %s BSSID: %hhX:%hhX:%hhX:%hhx:%hhx:%hhx RSSI: %hhd Ch: %hhd\r\n",
+                   ap[i].get_ssid(), get_security_string(ap[i].get_security()),
+                   ap[i].get_bssid()[0], ap[i].get_bssid()[1], ap[i].get_bssid()[2],
+                   ap[i].get_bssid()[3], ap[i].get_bssid()[4], ap[i].get_bssid()[5],
+                   ap[i].get_rssi(), ap[i].get_channel());
+        }
+        printf("\r\n");
+    }
+
+    void print_network_info()
+    {
+        /* print the network info */
+        SocketAddress a;
+        _net->get_ip_address(&a);
+        printf("IP address: %s\r\n", a.get_ip_address() ? a.get_ip_address() : "None");
+        _net->get_netmask(&a);
+        printf("Netmask: %s\r\n", a.get_ip_address() ? a.get_ip_address() : "None");
+        _net->get_gateway(&a);
+        printf("Gateway: %s\r\n", a.get_ip_address() ? a.get_ip_address() : "None");
+    }
+
+    static const char *get_security_string(nsapi_security_t sec)
+    {
+        switch (sec) {
+            case NSAPI_SECURITY_NONE:
+                return "None";
+            case NSAPI_SECURITY_WEP:
+                return "WEP";
+            case NSAPI_SECURITY_WPA:
+                return "WPA";
+            case NSAPI_SECURITY_WPA2:
+                return "WPA2";
+            case NSAPI_SECURITY_WPA_WPA2:
+                return "WPA/WPA2";
+            case NSAPI_SECURITY_UNKNOWN:
+            default:
+                return "Unknown";
+        }
+    }
+
+private:
+    NetworkInterface *_net;
+    TCPSocket socket;
+};
+
+int main() {
+    SocketDemo example;
+
+    printf("\r\nStarting socket demo\r\n\r\n");
+
+    example.run();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -21,9 +21,9 @@ class SocketDemo {
     static const size_t MAX_MESSAGE_RECEIVED_LENGTH = 100;
 
 public:
-    SocketDemo()
+    SocketDemo() : _net(NetworkInterface::get_default_instance())
     {
-        _net = NetworkInterface::get_default_instance();
+
     }
 
     ~SocketDemo()

--- a/main.cpp
+++ b/main.cpp
@@ -40,7 +40,12 @@ public:
 
         /* if we're using a wifi interface run a quick scan */
         if (_net->wifiInterface()) {
+            /* the scan is not required to connect and only serves to show visible access points */
             wifi_scan();
+
+            /* in this example we use credentials configured at compile time which are used by
+             * NetworkInterface::connect() but it's possible to do this at runtime by using the
+             * WiFiInterface::connect() which takes these parameters as arguments */
         }
 
         /* connect will perform the action appropriate to the interface type to connect to the network */

--- a/main.cpp
+++ b/main.cpp
@@ -113,7 +113,11 @@ private:
     bool send_http_request()
     {
         /* loop until whole request sent */
-        const char buffer[] = "GET / HTTP/1.1\nHost: ifconfig.io\nConnection: close\n\n";
+        const char buffer[] = R"(GET / HTTP/1.1
+Host: ifconfig.io
+Connection: close
+
+)";
 
         nsapi_size_t bytes_to_send = strlen(buffer);
 

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,8 +1,22 @@
 {
+    "config": {
+        "hostname": {
+            "help": "The demo will try to connect to this web address on port 80.",
+            "value": "\"ifconfig.io\""
+        }
+    },
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true,
-            "target.network-default-interface-type": "ETHERNET"
+            "nsapi.default-wifi-security": "WPA_WPA2",
+            "nsapi.default-wifi-ssid": "\"YOUR_SSID\"",
+            "nsapi.default-wifi-password": "\"YOUR_PASSWORD\"",
+            "platform.stdio-baud-rate": 115200
+        },
+        "DISCO_F413ZH": {
+            "target.components_add": ["ism43362"]
+        },
+        "DISCO_L475VG_IOT01A": {
+            "target.components_add": ["ism43362"]
         }
     }
 }


### PR DESCRIPTION
This brings the example more in line with others by making it more C++.
To reduce duplication and maintenance overhead I'm including wifi functionality in sockets.
It also unifies the readme and expands the wifi section.