### PR TITLE
Update for mbed-os-6.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,94 @@
+# Copyright (c) 2020 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: sh
+os: linux
+dist: xenial
+
+env:
+  global:
+    - PROFILE=develop
+
+cache:
+  pip: true
+  ccache: true
+  # It looks like ccache for arm-none-eabi is not yet supported by Travis.
+  # Therefore manually adding ccache directory to cache
+  directories:
+    - ${HOME}/.ccache
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
+    packages:
+      - cmake
+      - ninja-build
+
+matrix:
+  include:
+
+    - &cmake-build-test
+      stage: "CMake"
+      name: "CMake sockets example - develop (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=develop  CACHE_NAME=develop-K64F
+      language: python
+      python: 3.8
+      install:
+        # Setup ccache
+        - ccache -o compiler_check=content
+        - ccache -M 1G
+        - pushd /usr/lib/ccache
+        - sudo ln -s ../../bin/ccache arm-none-eabi-gcc
+        - sudo ln -s ../../bin/ccache arm-none-eabi-g++
+        - export PATH="/usr/lib/ccache:$PATH"
+        - popd
+        # Install arm-none-eabi-gcc
+        - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A" --output gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - tar xf gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        - popd
+        - arm-none-eabi-gcc --version
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
+        - pip install --upgrade mbed-tools
+        - pip install prettytable==0.7.2
+        - pip install future==0.16.0
+        - pip install "Jinja2>=2.10.1,<2.11"
+        - pip install "intelhex>=1.3,<=2.2.1"
+      script:
+        - mbedtools checkout
+        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - ccache -s
+
+    - <<: *cmake-build-test
+      name: "CMake sockets example - release (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=release CACHE_NAME=release-K64F
+
+    - <<: *cmake-build-test
+      name: "CMake sockets example - debug (K64F)"
+      env: NAME=cmake_test TARGET_NAME=K64F PROFILE=debug CACHE_NAME=debug-K64F
+

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/
+https://github.com/ARMmbed/mbed-os/#d6784c3ee6ada8e886801d0197904d3ab94c891c


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.6.0 release of mbed-os. 