### PR TITLE
Fix default interface on DISCO

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -25,6 +25,7 @@
         "DISCO_L475VG_IOT01A": {
             "target.components_add": ["ism43362"],
             "ism43362.provide-default": true,
+            "target.network-default-interface-type": "WIFI",
             "target.macros_add" : ["MBEDTLS_SHA1_C"]
         },
         "K64F": {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -16,6 +16,7 @@
 
 #include "mbed.h"
 #include "wifi_helper.h"
+#include "mbed-trace/mbed_trace.h"
 
 #if MBED_CONF_APP_USE_TLS_SOCKET
 #include "root_ca_cert.h"
@@ -251,7 +252,11 @@ private:
 int main() {
     printf("\r\nStarting socket demo\r\n\r\n");
 
-    SocketDemo *example = new SocketDemo;
+#ifdef MBED_CONF_MBED_TRACE_ENABLE
+    mbed_trace_init();
+#endif
+
+    SocketDemo *example = new SocketDemo();
     MBED_ASSERT(example);
     example->run();
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -90,7 +90,7 @@ public:
             printf("Error: _socket.set_root_ca_cert() returned %d\n", result);
             return;
         }
-        _socket.set_hostname("ifconfig.io");
+        _socket.set_hostname(MBED_CONF_APP_HOSTNAME);
 #endif // MBED_CONF_APP_USE_TLS_SOCKET
 
         /* now we have to find where to connect */


### PR DESCRIPTION
DISCO by default selects eth, a config is needed to use wifi.
Also init tracing when enabled and fix hardcoded hostname.