### PR TITLE
CMake: Make the application the top level CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,13 @@ set(APP_TARGET mbed-os-example-sockets)
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
 
 mbed_configure_app_target(${APP_TARGET})
-
-project(${APP_TARGET})
 
 target_include_directories(${APP_TARGET}
     PUBLIC


### PR DESCRIPTION
So CMake can work correctly we need to define our project before we add
dependencies, otherwise the project we depend on will be registered as
the current project.